### PR TITLE
test: add unit tests for createMDXLoaderItem crossCompilerCache confi…

### DIFF
--- a/packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {createMDXLoaderItem} from '../createMDXLoader';
+
+jest.mock('../processor', () => ({
+  createProcessors: jest.fn().mockResolvedValue({
+    mdxProcessor: {},
+    rehypeProcessor: {},
+  }),
+}));
+
+// describe creates a block that groups several related
+// tests into one test suite
+describe('createMDXLoader caching behavior', () => {
+  const originalEnv = process.env.NODE_ENV;
+  const originalJestWorkerId = process.env.JEST_WORKER_ID;
+
+  // before AND after each test
+  beforeEach(() => {
+    delete process.env.JEST_WORKER_ID;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    if (originalJestWorkerId !== undefined) {
+      process.env.JEST_WORKER_ID = originalJestWorkerId;
+    } else {
+      delete process.env.JEST_WORKER_ID;
+    }
+  });
+
+  // 1. caching is enabled in production mode
+  it('enables crossCompileCache when use crossCompilerCache=true and NODE_ENV=production', async () => {
+    // ARRANGE - set up the environment
+    process.env.NODE_ENV = 'production';
+
+    // ACT - call the function with specific options
+    const result = (await createMDXLoaderItem({
+      useCrossCompilerCache: true,
+    } as any)) as any;
+
+    // ASSERT - validate the results
+    // expect lets you validate conditions in tests
+    expect(typeof result).toBe('object');
+    expect(result).not.toBeNull();
+    expect('loader' in result).toBe(true);
+    expect(result.loader).toBe(require.resolve('@docusaurus/mdx-loader'));
+    expect(typeof result.options).toBe('object');
+    expect((result as any).options.crossCompilerCache).toBeInstanceOf(Map);
+  });
+
+  // 2. caching is disabled development mode, would cache old versions
+  it('disables crossCompileCache when crossCompilerCache=true but NODE_ENV=development', async () => {
+    // ARRANGE - set up the environment
+    process.env.NODE_ENV = 'development';
+
+    // ACT - call the function with specific options
+    // await pauses async function until a promise is kept
+    // Promise<RuleSetUseItem> in createMDXLoaderItem
+    const result = (await createMDXLoaderItem({
+      useCrossCompilerCache: true,
+    } as any)) as any;
+
+    // ASSERT - validate the results
+    expect(typeof result).toBe('object');
+    expect((result.options as any).crossCompilerCache).toBeUndefined();
+  });
+
+  // 3. caching is disabled when env is undefined
+  it('disables crossCompilerCache when useCrossCompilerCache=true but NODE_ENV is undefined', async () => {
+    // ARRANGE - set up the environment
+    delete process.env.NODE_ENV;
+
+    // ACT - call function with specific options
+    const result = (await createMDXLoaderItem({
+      useCrossCompilerCache: true,
+    } as any)) as any;
+
+    // ASSERT - validate the results
+    expect(typeof result).toBe('object');
+    expect((result.options as any).crossCompilerCache).toBeUndefined();
+  });
+
+  // 4. caching is disabled when useCrossCompilerCache is false, even in production
+  it('disables crossCompilerCache when useCrossCompilerCache=false in production', async () => {
+    // ARRANGE - set up the environment
+    process.env.NODE_ENV = 'production';
+
+    // ACT - call function with specific options
+    const result = (await createMDXLoaderItem({
+      useCrossCompilerCache: false,
+    } as any)) as any;
+
+    // ASSERT - validate the results
+    expect(typeof result).toBe('object');
+    expect((result.options as any).crossCompilerCache).toBeUndefined();
+  });
+
+  // 5.
+  it('disables crossCompilerCache when useCrossCompilerCache is not provided', async () => {
+    // ARRANGE - set up the environment
+    process.env.NODE_ENV = 'production';
+
+    // ACT - call the function with specific options
+    const result = (await createMDXLoaderItem({} as any)) as any;
+
+    // ASSERT - validate the results
+    expect(typeof result.options).toBe('object');
+    expect((result.options as any).crossCompilerCache).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes [#5](https://github.com/dpantaleoni/docusaurus/issues/5)
## Summary of what changed

- Added unit tests in /docusaurus/packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts
- Checks to ensure caching is enabled when crossCompilerCache=true and in production mode
- Disables caching when in development mode
- Disables caching when mode is unknown or undefined
- Disables caching when crossCompilerCache=false 

## How to run the relevant tests

From the repo root:

yarn test /docusaurus/packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts

To see code coverage:

yarn jest /docusaurus/packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts –coverage –collectCoverageFrom=’packages/docusaurus-mdx-loader/src/createMDXLoader.ts’

## Evidence

These changes protect the `createMDXLoaderItem` option normalization, ensuring the correct `crossCompilerCache` Map is only created when both `useCrossCompilerCache=true` and `NODE_ENV=production` are satisfied simultaneously. Without these tests, the following regressions would go undetected:
- If the production check was removed or changed, `crossCompilerCache` could be enabled in development mode, causing stale cached MDX to be served instead of freshly compiled content
- if the undefined/unknown environment handling was broken, ambiguous NODE_ENV values could accidentally enable caching, leading to unpredictable behavior


##Coverage improvement

|   Metric         |   Before   |   After        |
|---------------|------------|-------------|
|  Statements  |   7.69%   |    76.92%     |
|  Branches     |    0%       |     80%         |
|  Functions     |  66.66%  |   66.66%     | 
|  Lines            |  7.69%    |   76.92%     |
|  Uncovered   |  20-62     |  21, 55-62  |

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
