### PR TITLE
Swizzle normalization now initializes actions objects and defaults mi…

### DIFF
--- a/packages/docusaurus/src/commands/swizzle/config.ts
+++ b/packages/docusaurus/src/commands/swizzle/config.ts
@@ -12,7 +12,7 @@ import {getPluginByThemeName} from './themes';
 import type {SwizzleComponentConfig, SwizzleConfig} from '@docusaurus/types';
 import type {SwizzlePlugin} from './common';
 
-function getModuleSwizzleConfig(
+export function getModuleSwizzleConfig(
   swizzlePlugin: SwizzlePlugin,
 ): SwizzleConfig | undefined {
   const getSwizzleConfig =
@@ -79,6 +79,11 @@ export function normalizeSwizzleConfig(
 
   // Ensure all components always declare all actions
   Object.values(swizzleConfig.components).forEach((componentConfig) => {
+    if (!componentConfig.actions) {
+      // SET ACTIONS TO A DEFAULT VALUE WHEN NOT PRESENT
+      componentConfig.actions = {} as SwizzleComponentConfig['actions'];
+    }
+
     SwizzleActions.forEach((action) => {
       if (!componentConfig.actions[action]) {
         componentConfig.actions[action] = 'unsafe';


### PR DESCRIPTION
Closes [#21](https://github.com/dpantaleoni/docusaurus/issues/21)

## Summary of what changed

This PR adds unit tests for:

normalizeSwizzleConfig

The following behaviors are now explicitly tested:

- Accept components with no actions object

- Accept component with no description

- Accepts component with partial configuration

- Initialize missing actions objects during normalization to prevent runtime errors and ensure every component has a complete action map defaulting to ‘unsafe’



getModuleSwizzleConfig

The following edge cases are now validated:

- Validates config with empty components

- Returns undefined when no swizzle methods are provided


These tests improve regression protection around swizzle configuration validation and normalization logic, particularly for edge cases involving incomplete or minimal configurations.


## How to run the relevant tests

From repo root:

 yarn jest packages/docusaurus/src/commands/swizzle/__tests__/config.test.ts

To see coverage:

 yarn jest packages/docusaurus/src/commands/swizzle/__tests__/config.test.ts --coverage --collectCoverageFrom='packages/docusaurus/src/commands/swizzle/[config.ts](http://config.ts/)'

## Evidence
All new test cases pass locally

Tests cover edge cases involving:

- Empty components objects

- Missing actions

- Missing description

- Partial action definitions


1. No regressions introduced in existing swizzle related tests

2. Jest exits successfully with no runtime schema validation errors

3. CI compatible test invocation confirmed using targeted jest command above



## Coverage improvement

|   Metric          |   Before                        |   After                  |
|---------------|--------------------------|--------------------|
|  Statements  | 46.15%                         |    66.66%              |
|  Branches     | 27.77%                         |     72.22%             |
|  Functions     |  57.14%                        |   71.42%              | 
|  Lines            |  46.15%                        |   66.66%              |
|  Uncovered   |  15-47, 85, 100-114       | 31-42, 100-114  |


## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
