### PR TITLE
P3: URL resolution logic

### DIFF
--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -86,9 +86,12 @@ function resolveEditUrl(
   editUrl: PluginOptions['editUrl'],
   ctx: EditUrlContext,
 ): string | undefined {
-  if (typeof editUrl === 'function')
-    {return resolveFunctionEditUrl(editUrl, ctx);}
-  if (typeof editUrl === 'string') {return resolveStringEditUrl(editUrl, ctx);}
+  if (typeof editUrl === 'function') {
+    return resolveFunctionEditUrl(editUrl, ctx);
+  }
+  if (typeof editUrl === 'string') {
+    return resolveStringEditUrl(editUrl, ctx);
+  }
   return undefined;
 }
 

--- a/packages/docusaurus-plugin-content-docs/src/docs.ts
+++ b/packages/docusaurus-plugin-content-docs/src/docs.ts
@@ -36,10 +36,61 @@ import type {
   PropNavigationLink,
   VersionMetadata,
   LoadedVersion,
+  EditUrlFunction,
 } from '@docusaurus/plugin-content-docs';
 import type {LoadContext} from '@docusaurus/types';
 import type {SidebarsUtils} from './sidebars/utils';
 import type {DocFile} from './types';
+
+type EditUrlContext = {
+  relativeFilePath: string;
+  contentPath: string;
+  permalink: string;
+  versionMetadata: VersionMetadata;
+  locale: string;
+  siteDir: string;
+  editLocalizedFiles: boolean;
+};
+
+function resolveFunctionEditUrl(
+  editUrl: EditUrlFunction,
+  ctx: EditUrlContext,
+): string | undefined {
+  return editUrl({
+    version: ctx.versionMetadata.versionName,
+    versionDocsDirPath: posixPath(
+      path.relative(ctx.siteDir, ctx.versionMetadata.contentPath),
+    ),
+    docPath: posixPath(ctx.relativeFilePath),
+    permalink: ctx.permalink,
+    locale: ctx.locale,
+  });
+}
+
+function resolveStringEditUrl(
+  editUrl: string,
+  ctx: EditUrlContext,
+): string | undefined {
+  const isLocalized =
+    typeof ctx.versionMetadata.contentPathLocalized !== 'undefined' &&
+    ctx.contentPath === ctx.versionMetadata.contentPathLocalized;
+  const baseVersionEditUrl =
+    isLocalized && ctx.editLocalizedFiles
+      ? ctx.versionMetadata.editUrlLocalized
+      : ctx.versionMetadata.editUrl;
+
+  return getEditUrl(ctx.relativeFilePath, baseVersionEditUrl);
+}
+
+function resolveEditUrl(
+  editUrl: PluginOptions['editUrl'],
+  ctx: EditUrlContext,
+): string | undefined {
+  if (typeof editUrl === 'function')
+    {return resolveFunctionEditUrl(editUrl, ctx);}
+  if (typeof editUrl === 'string') {return resolveStringEditUrl(editUrl, ctx);}
+  return undefined;
+}
 
 export async function readDocFile(
   versionMetadata: Pick<
@@ -184,32 +235,6 @@ async function doProcessDocMetadata({
 
   const permalink = normalizeUrl([versionMetadata.path, docSlug]);
 
-  function getDocEditUrl() {
-    const relativeFilePath = path.relative(contentPath, filePath);
-
-    if (typeof options.editUrl === 'function') {
-      return options.editUrl({
-        version: versionMetadata.versionName,
-        versionDocsDirPath: posixPath(
-          path.relative(siteDir, versionMetadata.contentPath),
-        ),
-        docPath: posixPath(relativeFilePath),
-        permalink,
-        locale: context.i18n.currentLocale,
-      });
-    } else if (typeof options.editUrl === 'string') {
-      const isLocalized =
-        typeof versionMetadata.contentPathLocalized !== 'undefined' &&
-        contentPath === versionMetadata.contentPathLocalized;
-      const baseVersionEditUrl =
-        isLocalized && options.editLocalizedFiles
-          ? versionMetadata.editUrlLocalized
-          : versionMetadata.editUrl;
-      return getEditUrl(relativeFilePath, baseVersionEditUrl);
-    }
-    return undefined;
-  }
-
   const draft = isDraft({env, frontMatter});
   const unlisted = isUnlisted({env, frontMatter});
 
@@ -220,6 +245,16 @@ async function doProcessDocMetadata({
     tagsBaseRoutePath: versionMetadata.tagsPath,
     tagsFile,
   });
+
+  const ctx: EditUrlContext = {
+    relativeFilePath: path.relative(contentPath, filePath),
+    contentPath,
+    permalink,
+    versionMetadata,
+    locale: context.i18n.currentLocale,
+    siteDir,
+    editLocalizedFiles: options.editLocalizedFiles,
+  };
 
   // Assign all of object properties during instantiation (if possible) for
   // NodeJS optimization.
@@ -235,7 +270,10 @@ async function doProcessDocMetadata({
     permalink,
     draft,
     unlisted,
-    editUrl: customEditURL !== undefined ? customEditURL : getDocEditUrl(),
+    editUrl:
+      customEditURL !== undefined
+        ? customEditURL
+        : resolveEditUrl(options.editUrl, ctx),
     tags,
     version: versionMetadata.versionName,
     lastUpdatedBy: lastUpdate.lastUpdatedBy,


### PR DESCRIPTION
Closes [#62](https://github.com/dpantaleoni/docusaurus/issues/62)

## Summary of changes

The edit URL logic resolution logic has been extracted into three functions: `resolveFunctionEditUrl` handles when editUrl is a function, `resolveStringEditUrl` handles when editUrl is a string, and `resolveEditUrl` delegates the appropriate resolver at runtime. 

## Verification

yarn test passes all tests after refactor

## Evidence

<img width="2145" height="1687" alt="PR" src="https://github.com/user-attachments/assets/29026c28-68db-4ab9-8b28-4076f96bab2a" />


## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

<!--
Please also remember to sign the CLA, although you can also sign it after submitting the PR. The CLA is required for us to merge your PR.
If this PR adds or changes functionality, please take some time to update the docs. You can also write docs after the API design is finalized and the code changes have been approved.
-->

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

### Test links

<!--
🙏 Please add an exhaustive list of links relevant to this pull request.
⏱ This saves maintainers a lot of time during reviews.

- If you changed anything that's displayed on UI, please add a dogfooding page in website/_dogfooding to help us preview the effect. Those tests are deployed at https://docusaurus.io/tests
- If you changed documentation, please link to the new and updated documentation pages.

After submission, our Netlify bot will post a deploy preview link in comment, in the format of https://deploy-preview-<PR-NUMBER>--docusaurus-2.netlify.app/. Once available, please edit this section with links to the relevant deploy preview pages.

Please don't be afraid to change the main site's configuration as well! You can make use of your new feature on our site so we can preview its effects. We can decide if it should be kept in production before merging it.
-->

Deploy preview: https://deploy-preview-_____--docusaurus-2.netlify.app/

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
