### PR TITLE
P3/issue 78 scope mutable state via factory

### DIFF
--- a/packages/docusaurus-utils/src/__tests__/emitUtils.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/emitUtils.test.ts
@@ -8,7 +8,7 @@
 import {jest} from '@jest/globals';
 import path from 'path';
 import fs from 'fs-extra';
-import {readOutputHTMLFile, generate} from '../emitUtils';
+import {createFileEmitter, readOutputHTMLFile, generate} from '../emitUtils';
 
 describe('readOutputHTMLFile', () => {
   it('reads both files with trailing slash undefined', async () => {
@@ -154,5 +154,18 @@ describe('generate', () => {
       path.join(__dirname, 'foo'),
       'bar',
     );
+  });
+
+  it('has instance-scoped cache with createFileEmitter()', async () => {
+    writeMock.mockClear();
+    existsMock.mockImplementation(() => false);
+
+    const emitterA = createFileEmitter();
+    const emitterB = createFileEmitter();
+
+    await emitterA.generate(__dirname, 'scoped.txt', 'hello');
+    await emitterB.generate(__dirname, 'scoped.txt', 'hello');
+
+    expect(writeMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/docusaurus-utils/src/emitUtils.ts
+++ b/packages/docusaurus-utils/src/emitUtils.ts
@@ -10,10 +10,17 @@ import fs from 'fs-extra';
 import {createHash} from 'crypto';
 import {findAsyncSequential} from './jsUtils';
 
-const fileHash = new Map<string, string>();
-
 const hashContent = (content: string): string => {
   return createHash('md5').update(content).digest('hex');
+};
+
+export type FileEmitter = {
+  generate: (
+    generatedFilesDir: string,
+    file: string,
+    content: string,
+    skipCache?: boolean,
+  ) => Promise<void>;
 };
 
 /**
@@ -27,44 +34,56 @@ const hashContent = (content: string): string => {
  * @param skipCache If `true` (defaults as `true` for production), file is
  * force-rewritten, skipping cache.
  */
-export async function generate(
-  generatedFilesDir: string,
-  file: string,
-  content: string,
-  skipCache: boolean = process.env.NODE_ENV === 'production',
-): Promise<void> {
-  const filepath = path.resolve(generatedFilesDir, file);
+export function createFileEmitter(): FileEmitter {
+  const fileHash = new Map<string, string>();
 
-  if (skipCache) {
-    await fs.outputFile(filepath, content);
-    // Cache still needs to be reset, otherwise, writing "A", "B", and "A" where
-    // "B" skips cache will cause the last "A" not be able to overwrite as the
-    // first "A" remains in cache. But if the file never existed in cache, no
-    // need to register it.
-    if (fileHash.get(filepath)) {
-      fileHash.set(filepath, hashContent(content));
+  const generate: FileEmitter['generate'] = async (
+    generatedFilesDir,
+    file,
+    content,
+    skipCache = process.env.NODE_ENV === 'production',
+  ) => {
+    const filepath = path.resolve(generatedFilesDir, file);
+
+    if (skipCache) {
+      await fs.outputFile(filepath, content);
+      // Cache still needs to be reset, otherwise, writing "A", "B", and "A" where
+      // "B" skips cache will cause the last "A" not be able to overwrite as the
+      // first "A" remains in cache. But if the file never existed in cache, no
+      // need to register it.
+      if (fileHash.get(filepath)) {
+        fileHash.set(filepath, hashContent(content));
+      }
+      return;
     }
-    return;
-  }
 
-  let lastHash = fileHash.get(filepath);
+    let lastHash = fileHash.get(filepath);
 
-  // If file already exists but it's not in runtime cache yet, we try to
-  // calculate the content hash and then compare. This is to avoid unnecessary
-  // overwriting and we can reuse old file.
-  if (!lastHash && (await fs.pathExists(filepath))) {
-    const lastContent = await fs.readFile(filepath, 'utf8');
-    lastHash = hashContent(lastContent);
-    fileHash.set(filepath, lastHash);
-  }
+    // If file already exists but it's not in runtime cache yet, we try to
+    // calculate the content hash and then compare. This is to avoid unnecessary
+    // overwriting and we can reuse old file.
+    if (!lastHash && (await fs.pathExists(filepath))) {
+      const lastContent = await fs.readFile(filepath, 'utf8');
+      lastHash = hashContent(lastContent);
+      fileHash.set(filepath, lastHash);
+    }
 
-  const currentHash = hashContent(content);
+    const currentHash = hashContent(content);
 
-  if (lastHash !== currentHash) {
-    await fs.outputFile(filepath, content);
-    fileHash.set(filepath, currentHash);
-  }
+    if (lastHash !== currentHash) {
+      await fs.outputFile(filepath, content);
+      fileHash.set(filepath, currentHash);
+    }
+  };
+
+  return {generate};
 }
+
+const defaultFileEmitter = createFileEmitter();
+
+export const generate: FileEmitter['generate'] = (...args) => {
+  return defaultFileEmitter.generate(...args);
+};
 
 /**
  * @param permalink The URL that the HTML file corresponds to, without base URL

--- a/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
+++ b/packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {jest} from '@jest/globals';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
@@ -12,6 +13,8 @@ import execa from 'execa';
 
 import {
   FileNotTrackedError,
+  GitNotFoundError,
+  createGitInfoReader,
   getFileCommitDate,
   getGitLastUpdate,
   getGitCreation,
@@ -387,6 +390,35 @@ describe('commit info APIs', () => {
           },
         }
       `);
+    });
+  });
+
+  describe('createGitInfoReader()', () => {
+    it('scopes warning flags to each reader instance', async () => {
+      const warnA = jest.fn();
+      const warnB = jest.fn();
+
+      const getFileCommitDateAlwaysNoGit = async () => {
+        throw new GitNotFoundError('no git');
+      };
+
+      const readerA = createGitInfoReader({
+        logger: {warn: warnA},
+        // @ts-expect-error: test stub throws
+        getFileCommitDate: getFileCommitDateAlwaysNoGit,
+      });
+      const readerB = createGitInfoReader({
+        logger: {warn: warnB},
+        // @ts-expect-error: test stub throws
+        getFileCommitDate: getFileCommitDateAlwaysNoGit,
+      });
+
+      await expect(readerA.getGitLastUpdate('/any')).resolves.toBeNull();
+      await expect(readerA.getGitLastUpdate('/any')).resolves.toBeNull();
+      expect(warnA).toHaveBeenCalledTimes(1);
+
+      await expect(readerB.getGitLastUpdate('/any')).resolves.toBeNull();
+      expect(warnB).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/docusaurus-utils/src/vcs/gitUtils.ts
+++ b/packages/docusaurus-utils/src/vcs/gitUtils.ts
@@ -207,62 +207,83 @@ export async function getFileCommitDate(
   return {date, timestamp};
 }
 
-let showedGitRequirementError = false;
-let showedFileNotTrackedError = false;
-
 type GitCommitInfo = {timestamp: number; author: string};
 
-async function getGitCommitInfo(
-  filePath: string,
-  age: 'oldest' | 'newest',
-): Promise<GitCommitInfo | null> {
-  if (!filePath) {
-    return null;
-  }
-  // Wrap in try/catch in case the shell commands fail
-  // (e.g. project doesn't use Git, etc).
-  try {
-    const result = await getFileCommitDate(filePath, {
-      age,
-      includeAuthor: true,
-    });
-    return {timestamp: result.timestamp, author: result.author};
-  } catch (err) {
-    // Task: legacy perf issue: do not use exceptions for control flow!
-    if (err instanceof GitNotFoundError) {
-      if (!showedGitRequirementError) {
-        logger.warn('Sorry, the last update options require Git.');
-        showedGitRequirementError = true;
-      }
-    } else if (err instanceof FileNotTrackedError) {
-      if (!showedFileNotTrackedError) {
-        logger.warn(
-          'Cannot infer the update date for some files, as they are not tracked by git.',
-        );
-        showedFileNotTrackedError = true;
-      }
-    } else {
-      throw new Error(
-        `An error occurred when trying to get the file ${
-          age === 'oldest' ? 'creation' : 'last update'
-        } date from Git`,
-        {cause: err},
-      );
+export type GitInfoReader = {
+  getGitLastUpdate: (filePath: string) => Promise<GitCommitInfo | null>;
+  getGitCreation: (filePath: string) => Promise<GitCommitInfo | null>;
+};
+
+export function createGitInfoReader(options?: {
+  logger?: Pick<typeof logger, 'warn'>;
+  getFileCommitDate?: typeof getFileCommitDate;
+}): GitInfoReader {
+  const loggerInstance = options?.logger ?? logger;
+  const getFileCommitDateInstance =
+    options?.getFileCommitDate ?? getFileCommitDate;
+
+  let showedGitRequirementError = false;
+  let showedFileNotTrackedError = false;
+
+  async function getGitCommitInfo(
+    filePath: string,
+    age: 'oldest' | 'newest',
+  ): Promise<GitCommitInfo | null> {
+    if (!filePath) {
+      return null;
     }
-    return null;
+    // Wrap in try/catch in case the shell commands fail
+    // (e.g. project doesn't use Git, etc).
+    try {
+      const result = await getFileCommitDateInstance(filePath, {
+        age,
+        includeAuthor: true,
+      });
+      return {timestamp: result.timestamp, author: result.author};
+    } catch (err) {
+      // Task: legacy perf issue: do not use exceptions for control flow!
+      if (err instanceof GitNotFoundError) {
+        if (!showedGitRequirementError) {
+          loggerInstance.warn('Sorry, the last update options require Git.');
+          showedGitRequirementError = true;
+        }
+      } else if (err instanceof FileNotTrackedError) {
+        if (!showedFileNotTrackedError) {
+          loggerInstance.warn(
+            'Cannot infer the update date for some files, as they are not tracked by git.',
+          );
+          showedFileNotTrackedError = true;
+        }
+      } else {
+        throw new Error(
+          `An error occurred when trying to get the file ${
+            age === 'oldest' ? 'creation' : 'last update'
+          } date from Git`,
+          {cause: err},
+        );
+      }
+      return null;
+    }
   }
+
+  return {
+    getGitLastUpdate: (filePath) => getGitCommitInfo(filePath, 'newest'),
+    getGitCreation: (filePath) => getGitCommitInfo(filePath, 'oldest'),
+  };
 }
+
+const defaultGitInfoReader = createGitInfoReader();
 
 export async function getGitLastUpdate(
   filePath: string,
 ): Promise<GitCommitInfo | null> {
-  return getGitCommitInfo(filePath, 'newest');
+  return defaultGitInfoReader.getGitLastUpdate(filePath);
 }
 
 export async function getGitCreation(
   filePath: string,
 ): Promise<GitCommitInfo | null> {
-  return getGitCommitInfo(filePath, 'oldest');
+  return defaultGitInfoReader.getGitCreation(filePath);
 }
 
 export async function getGitRepoRoot(cwd: string): Promise<string> {


### PR DESCRIPTION
## Problem
Some utilities in `@docusaurus/utils` kept mutable module-scoped state (emit cache and git warning flags). This can leak across independent callers/tests and makes behavior depend on process lifetime rather than the instance using the helper.
## Approach
- Refactored emit helpers to scope the file cache per factory-created emitter instance.
- Refactored git helpers to scope "warn once" flags per factory-created git info reader instance.
- Kept top-level functions exported as thin wrappers around a default singleton instance, so existing callers do not change.
- Added tests asserting instance-scoped behavior for both utilities.
## Evidence
- Tests passed (note: required running outside the IDE sandbox because the git fixture uses `git init`, which needs to create `.git/hooks` in a temp directory):
  `npm test -- --runTestsByPath packages/docusaurus-utils/src/__tests__/emitUtils.test.ts packages/docusaurus-utils/src/vcs/__tests__/gitUtils.test.ts`
- Diffstat: 4 files changed, 160 insertions(+), 75 deletions(-).
Closes #78