### PR TITLE
P3/issue 80 content helpers template method

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/contentHelpers.ts
+++ b/packages/docusaurus-plugin-content-blog/src/contentHelpers.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {createContentHelpersFactory} from '@docusaurus/utils';
 import type {BlogContent, BlogPost} from '@docusaurus/plugin-content-blog';
 
 function indexBlogPostsBySource(content: BlogContent): Map<string, BlogPost> {
@@ -21,15 +22,12 @@ export function createContentHelpers() {
   const sourceToBlogPost = new Map<string, BlogPost>();
   const sourceToPermalink = new Map<string, string>();
 
-  // Mutable map update :/
-  function updateContent(content: BlogContent): void {
-    sourceToBlogPost.clear();
-    sourceToPermalink.clear();
-    indexBlogPostsBySource(content).forEach((value, key) => {
-      sourceToBlogPost.set(key, value);
-      sourceToPermalink.set(key, value.metadata.permalink);
-    });
-  }
+  const {updateContent} = createContentHelpersFactory({
+    sourceToValue: sourceToBlogPost,
+    sourceToPermalink,
+    createSourceToValue: indexBlogPostsBySource,
+    getValuePermalink: (blogPost) => blogPost.metadata.permalink,
+  });
 
   return {updateContent, sourceToBlogPost, sourceToPermalink};
 }

--- a/packages/docusaurus-plugin-content-docs/src/contentHelpers.ts
+++ b/packages/docusaurus-plugin-content-docs/src/contentHelpers.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {createContentHelpersFactory} from '@docusaurus/utils';
 import type {DocMetadata, LoadedContent} from '@docusaurus/plugin-content-docs';
 
 function indexDocsBySource(content: LoadedContent): Map<string, DocMetadata> {
@@ -20,15 +21,12 @@ export function createContentHelpers() {
   const sourceToDoc = new Map<string, DocMetadata>();
   const sourceToPermalink = new Map<string, string>();
 
-  // Mutable map update :/
-  function updateContent(content: LoadedContent): void {
-    sourceToDoc.clear();
-    sourceToPermalink.clear();
-    indexDocsBySource(content).forEach((value, key) => {
-      sourceToDoc.set(key, value);
-      sourceToPermalink.set(key, value.permalink);
-    });
-  }
+  const {updateContent} = createContentHelpersFactory({
+    sourceToValue: sourceToDoc,
+    sourceToPermalink,
+    createSourceToValue: indexDocsBySource,
+    getValuePermalink: (doc) => doc.permalink,
+  });
 
   return {updateContent, sourceToDoc, sourceToPermalink};
 }

--- a/packages/docusaurus-plugin-content-pages/src/contentHelpers.ts
+++ b/packages/docusaurus-plugin-content-pages/src/contentHelpers.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {createContentHelpersFactory} from '@docusaurus/utils';
 import type {LoadedContent, Metadata} from '@docusaurus/plugin-content-pages';
 
 function indexPagesBySource(content: LoadedContent): Map<string, Metadata> {
@@ -19,15 +20,12 @@ export function createContentHelpers() {
   const sourceToPage = new Map<string, Metadata>();
   const sourceToPermalink = new Map<string, string>();
 
-  // Mutable map update :/
-  function updateContent(content: LoadedContent): void {
-    sourceToPage.clear();
-    sourceToPermalink.clear();
-    indexPagesBySource(content).forEach((value, key) => {
-      sourceToPage.set(key, value);
-      sourceToPermalink.set(key, value.permalink);
-    });
-  }
+  const {updateContent} = createContentHelpersFactory({
+    sourceToValue: sourceToPage,
+    sourceToPermalink,
+    createSourceToValue: indexPagesBySource,
+    getValuePermalink: (page) => page.permalink,
+  });
 
   return {updateContent, sourceToPage, sourceToPermalink};
 }

--- a/packages/docusaurus-utils/src/__tests__/contentHelpersFactory.test.ts
+++ b/packages/docusaurus-utils/src/__tests__/contentHelpersFactory.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {createContentHelpersFactory} from '../contentHelpersFactory';
+
+describe('createContentHelpersFactory', () => {
+  it('clears and repopulates both maps', () => {
+    type Item = {source: string; permalink: string; title: string};
+    type Content = {items: Item[]};
+
+    const sourceToItem = new Map<string, Item>();
+    const sourceToPermalink = new Map<string, string>();
+
+    const {updateContent} = createContentHelpersFactory<
+      Content,
+      Item,
+      typeof sourceToItem
+    >({
+      sourceToValue: sourceToItem,
+      sourceToPermalink,
+      createSourceToValue: (content) =>
+        new Map(content.items.map((item) => [item.source, item])),
+      getValuePermalink: (item) => item.permalink,
+    });
+
+    updateContent({
+      items: [
+        {source: '/a.mdx', permalink: '/a', title: 'A'},
+        {source: '/b.mdx', permalink: '/b', title: 'B'},
+      ],
+    });
+
+    expect(Array.from(sourceToItem.keys())).toEqual(['/a.mdx', '/b.mdx']);
+    expect(sourceToItem.get('/a.mdx')?.title).toBe('A');
+    expect(sourceToPermalink.get('/b.mdx')).toBe('/b');
+
+    updateContent({
+      items: [{source: '/c.mdx', permalink: '/c', title: 'C'}],
+    });
+
+    expect(Array.from(sourceToItem.keys())).toEqual(['/c.mdx']);
+    expect(sourceToPermalink.size).toBe(1);
+    expect(sourceToPermalink.get('/c.mdx')).toBe('/c');
+    expect(sourceToPermalink.has('/a.mdx')).toBe(false);
+  });
+});

--- a/packages/docusaurus-utils/src/contentHelpersFactory.ts
+++ b/packages/docusaurus-utils/src/contentHelpersFactory.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+type SourceToPermalink = Map<string, string>;
+
+export type CreateContentHelpersFactoryParams<
+  TContent,
+  TValue,
+  TValueMap extends Map<string, TValue>,
+> = {
+  sourceToValue: TValueMap;
+  sourceToPermalink: SourceToPermalink;
+  createSourceToValue: (content: TContent) => Map<string, TValue>;
+  getValuePermalink: (value: TValue) => string;
+};
+
+export function createContentHelpersFactory<
+  TContent,
+  TValue,
+  TValueMap extends Map<string, TValue>,
+>({
+  sourceToValue,
+  sourceToPermalink,
+  createSourceToValue,
+  getValuePermalink,
+}: CreateContentHelpersFactoryParams<TContent, TValue, TValueMap>): {
+  updateContent: (content: TContent) => void;
+} {
+  function updateContent(content: TContent): void {
+    sourceToValue.clear();
+    sourceToPermalink.clear();
+
+    createSourceToValue(content).forEach((value, source) => {
+      sourceToValue.set(source, value);
+      sourceToPermalink.set(source, getValuePermalink(value));
+    });
+  }
+
+  return {updateContent};
+}

--- a/packages/docusaurus-utils/src/index.ts
+++ b/packages/docusaurus-utils/src/index.ts
@@ -130,3 +130,8 @@ export {
 export {VcsPresetNames, getVcsPreset, TEST_VCS} from './vcs/vcs';
 
 export {normalizeTags, reportInlineTags} from './tags';
+
+export {
+  createContentHelpersFactory,
+  type CreateContentHelpersFactoryParams,
+} from './contentHelpersFactory';


### PR DESCRIPTION
## Problem
Docs/blog/pages plugins each re-implement the same mutable-map "content helpers" update algorithm:
- clear `sourceToX` and `sourceToPermalink`
- re-index content by source
- repopulate both maps (including permalink extraction)

This duplicates logic and makes future changes easy to miss.

## Approach
- Added a small Template Method-like factory in `@docusaurus/utils` that captures the shared algorithm:
  - clear maps -> iterate entries -> set source->value and source->permalink
  - plugin-specific steps are provided as callbacks: `createSourceToValue(content)` and `getValuePermalink(value)`.
- Refactored `createContentHelpers()` in docs/blog/pages to delegate to the shared factory.
- Preserved the public shape and map names (`sourceToDoc` / `sourceToBlogPost` / `sourceToPage` and `sourceToPermalink`) so call sites do not change.
- Added a focused unit test asserting the factory's clear-and-repopulate semantics.

## Evidence
- Jest:
  `npm test -- --runTestsByPath packages/docusaurus-utils/src/__tests__/contentHelpersFactory.test.ts --modulePathIgnorePatterns "/packages/.*/lib"`

Closes #80