### PR TITLE
P3/issue 77 mdx options builder

### DIFF
--- a/packages/docusaurus-mdx-loader/src/__tests__/__snapshots__/optionsBuilder.test.ts.snap
+++ b/packages/docusaurus-mdx-loader/src/__tests__/__snapshots__/optionsBuilder.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`createMDXLoaderOptionsBuilder produces the same options as manual assembly 1`] = `
+{
+  "admonitions": true,
+  "isMDXPartial": [Function],
+  "markdownConfig": {
+    "mermaid": true,
+  },
+  "siteDir": "/mySite",
+  "staticDirs": [
+    "/mySite/static",
+    "/mySite/static2",
+  ],
+  "useCrossCompilerCache": true,
+}
+`;

--- a/packages/docusaurus-mdx-loader/src/__tests__/optionsBuilder.test.ts
+++ b/packages/docusaurus-mdx-loader/src/__tests__/optionsBuilder.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import path from 'path';
+import {createMDXLoaderOptionsBuilder} from '../options';
+
+describe('createMDXLoaderOptionsBuilder', () => {
+  it('produces the same options as manual assembly', () => {
+    const siteDir = '/mySite';
+    const siteConfig = {
+      staticDirectories: ['static', 'static2'],
+      markdown: {mermaid: true} as any,
+    };
+
+    const overrides = {
+      admonitions: true,
+      isMDXPartial: () => true,
+    } as const;
+
+    const built = createMDXLoaderOptionsBuilder({
+      siteDir,
+      siteConfig,
+      useCrossCompilerCache: true,
+    }).build(overrides as any);
+
+    const manual = {
+      siteDir,
+      staticDirs: siteConfig.staticDirectories.map((dir) =>
+        path.resolve(siteDir, dir),
+      ),
+      markdownConfig: siteConfig.markdown,
+      useCrossCompilerCache: true,
+      ...overrides,
+    };
+
+    expect(built).toEqual(manual);
+    expect(built).toMatchSnapshot();
+  });
+});

--- a/packages/docusaurus-mdx-loader/src/index.ts
+++ b/packages/docusaurus-mdx-loader/src/index.ts
@@ -42,3 +42,7 @@ export type LoadedMDXContent<FrontMatter, Metadata, Assets = undefined> = {
 export type {MDXPlugin} from './loader';
 export type {MDXOptions} from './processor';
 export type {Options} from './options';
+export {
+  createMDXLoaderOptionsBuilder,
+  type MDXLoaderOptionsBuilderSiteConfig,
+} from './options';

--- a/packages/docusaurus-mdx-loader/src/options.ts
+++ b/packages/docusaurus-mdx-loader/src/options.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import path from 'path';
 import type {MDXOptions, SimpleProcessors} from './processor';
 import type {MarkdownConfig} from '@docusaurus/types';
 import type {ResolveMarkdownLink} from './remark/resolveMarkdownLinks';
@@ -32,3 +33,43 @@ export type Options = Partial<MDXOptions> & {
 };
 
 type CrossCompilerCacheEntry = PromiseWithResolvers<string>;
+
+export type MDXLoaderOptionsBuilderSiteConfig = {
+  staticDirectories: string[];
+  markdown: MarkdownConfig;
+};
+
+export function createMDXLoaderOptionsBuilder({
+  siteDir,
+  siteConfig,
+  useCrossCompilerCache,
+}: {
+  siteDir: string;
+  siteConfig: MDXLoaderOptionsBuilderSiteConfig;
+  useCrossCompilerCache?: boolean;
+}): {
+  build: (
+    overrides: Omit<Options, 'siteDir' | 'staticDirs' | 'markdownConfig'>,
+  ) => Options;
+} {
+  const baseOptions: Pick<
+    Options,
+    'siteDir' | 'staticDirs' | 'markdownConfig' | 'useCrossCompilerCache'
+  > = {
+    siteDir,
+    staticDirs: siteConfig.staticDirectories.map((dir) =>
+      path.resolve(siteDir, dir),
+    ),
+    markdownConfig: siteConfig.markdown,
+    useCrossCompilerCache,
+  };
+
+  return {
+    build(overrides) {
+      return {
+        ...baseOptions,
+        ...overrides,
+      };
+    },
+  };
+}

--- a/packages/docusaurus-plugin-content-blog/src/index.ts
+++ b/packages/docusaurus-plugin-content-blog/src/index.ts
@@ -21,7 +21,10 @@ import {
   getLocaleConfig,
 } from '@docusaurus/utils';
 import {getTagsFilePathsToWatch} from '@docusaurus/utils-validation';
-import {createMDXLoaderItem} from '@docusaurus/mdx-loader';
+import {
+  createMDXLoaderItem,
+  createMDXLoaderOptionsBuilder,
+} from '@docusaurus/mdx-loader';
 import {
   getBlogTags,
   shouldBeListed,
@@ -112,56 +115,61 @@ export default async function pluginContentBlog(
 
     const contentDirs = getContentPathList(contentPaths);
 
-    const mdxLoaderItem = await createMDXLoaderItem({
+    const mdxOptionsBuilder = createMDXLoaderOptionsBuilder({
+      siteDir,
+      siteConfig,
       useCrossCompilerCache:
         siteConfig.future.experimental_faster.mdxCrossCompilerCache,
-      admonitions,
-      remarkPlugins,
-      rehypePlugins,
-      recmaPlugins,
-      beforeDefaultRemarkPlugins: [
-        footnoteIDFixer,
-        ...beforeDefaultRemarkPlugins,
-      ],
-      beforeDefaultRehypePlugins,
-      staticDirs: siteConfig.staticDirectories.map((dir) =>
-        path.resolve(siteDir, dir),
-      ),
-      siteDir,
-      isMDXPartial: createAbsoluteFilePathMatcher(options.exclude, contentDirs),
-      metadataPath: (mdxPath: string) => {
-        // Note that metadataPath must be the same/in-sync as
-        // the path from createData for each MDX.
-        const aliasedPath = aliasedSitePath(mdxPath, siteDir);
-        return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
-      },
-      // For blog posts a title in markdown is always removed
-      // Blog posts title are rendered separately
-      removeContentTitle: true,
-      // createAssets converts relative paths to require() calls
-      createAssets: ({filePath}: {filePath: string}): Assets => {
-        const blogPost = contentHelpers.sourceToBlogPost.get(
-          aliasedSitePath(filePath, siteDir),
-        )!;
-        if (!blogPost) {
-          throw new Error(`Blog post not found for  filePath=${filePath}`);
-        }
-        return {
-          image: blogPost.metadata.frontMatter.image as string,
-          authorsImageUrls: blogPost.metadata.authors.map(
-            (author) => author.imageURL,
-          ),
-        };
-      },
-      markdownConfig: siteConfig.markdown,
-      resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
-        return resolveMarkdownLinkPathname(linkPathname, {
-          sourceFilePath,
-          sourceToPermalink: contentHelpers.sourceToPermalink,
-          siteDir,
-          contentPaths,
-        });
-      },
+    });
+
+    const mdxLoaderItem = await createMDXLoaderItem({
+      ...mdxOptionsBuilder.build({
+        admonitions,
+        remarkPlugins,
+        rehypePlugins,
+        recmaPlugins,
+        beforeDefaultRemarkPlugins: [
+          footnoteIDFixer,
+          ...beforeDefaultRemarkPlugins,
+        ],
+        beforeDefaultRehypePlugins,
+        isMDXPartial: createAbsoluteFilePathMatcher(
+          options.exclude,
+          contentDirs,
+        ),
+        metadataPath: (mdxPath: string) => {
+          // Note that metadataPath must be the same/in-sync as
+          // the path from createData for each MDX.
+          const aliasedPath = aliasedSitePath(mdxPath, siteDir);
+          return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
+        },
+        // For blog posts a title in markdown is always removed
+        // Blog posts title are rendered separately
+        removeContentTitle: true,
+        // createAssets converts relative paths to require() calls
+        createAssets: ({filePath}: {filePath: string}): Assets => {
+          const blogPost = contentHelpers.sourceToBlogPost.get(
+            aliasedSitePath(filePath, siteDir),
+          )!;
+          if (!blogPost) {
+            throw new Error(`Blog post not found for  filePath=${filePath}`);
+          }
+          return {
+            image: blogPost.metadata.frontMatter.image as string,
+            authorsImageUrls: blogPost.metadata.authors.map(
+              (author) => author.imageURL,
+            ),
+          };
+        },
+        resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
+          return resolveMarkdownLinkPathname(linkPathname, {
+            sourceFilePath,
+            sourceToPermalink: contentHelpers.sourceToPermalink,
+            siteDir,
+            contentPaths,
+          });
+        },
+      }),
     });
 
     function createBlogMarkdownLoader(): RuleSetUseItem {

--- a/packages/docusaurus-plugin-content-docs/src/index.ts
+++ b/packages/docusaurus-plugin-content-docs/src/index.ts
@@ -19,7 +19,10 @@ import {
   DEFAULT_PLUGIN_ID,
 } from '@docusaurus/utils';
 import {getTagsFilePathsToWatch} from '@docusaurus/utils-validation';
-import {createMDXLoaderRule} from '@docusaurus/mdx-loader';
+import {
+  createMDXLoaderOptionsBuilder,
+  createMDXLoaderRule,
+} from '@docusaurus/mdx-loader';
 import {resolveSidebarPathOption} from './sidebars';
 import {CategoryMetadataFilenamePattern} from './sidebars/generator';
 import {type DocEnv} from './docs';
@@ -120,56 +123,57 @@ export default async function pluginContentDocs(
       // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
       .map(addTrailingPathSeparator);
 
+    const mdxOptionsBuilder = createMDXLoaderOptionsBuilder({
+      siteDir,
+      siteConfig,
+      useCrossCompilerCache:
+        siteConfig.future.experimental_faster.mdxCrossCompilerCache,
+    });
+
     return createMDXLoaderRule({
       include: contentDirs,
       options: {
-        dependencies: [
-          await createMdxLoaderDependencyFile({
-            dataDir,
-            options,
-            versionsMetadata,
+        ...mdxOptionsBuilder.build({
+          dependencies: [
+            await createMdxLoaderDependencyFile({
+              dataDir,
+              options,
+              versionsMetadata,
+            }),
+          ].filter((d): d is string => typeof d === 'string'),
+          admonitions: options.admonitions,
+          remarkPlugins,
+          rehypePlugins,
+          recmaPlugins,
+          beforeDefaultRehypePlugins,
+          beforeDefaultRemarkPlugins,
+          isMDXPartial: createAbsoluteFilePathMatcher(
+            options.exclude,
+            contentDirs,
+          ),
+          metadataPath: (mdxPath: string) => {
+            // Note that metadataPath must be the same/in-sync as
+            // the path from createData for each MDX.
+            const aliasedPath = aliasedSitePath(mdxPath, siteDir);
+            return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
+          },
+          // createAssets converts relative paths to require() calls
+          createAssets: ({frontMatter}: {frontMatter: DocFrontMatter}) => ({
+            image: frontMatter.image,
           }),
-        ].filter((d): d is string => typeof d === 'string'),
-
-        useCrossCompilerCache:
-          siteConfig.future.experimental_faster.mdxCrossCompilerCache,
-        admonitions: options.admonitions,
-        remarkPlugins,
-        rehypePlugins,
-        recmaPlugins,
-        beforeDefaultRehypePlugins,
-        beforeDefaultRemarkPlugins,
-        staticDirs: siteConfig.staticDirectories.map((dir) =>
-          path.resolve(siteDir, dir),
-        ),
-        siteDir,
-        isMDXPartial: createAbsoluteFilePathMatcher(
-          options.exclude,
-          contentDirs,
-        ),
-        metadataPath: (mdxPath: string) => {
-          // Note that metadataPath must be the same/in-sync as
-          // the path from createData for each MDX.
-          const aliasedPath = aliasedSitePath(mdxPath, siteDir);
-          return path.join(dataDir, `${docuHash(aliasedPath)}.json`);
-        },
-        // createAssets converts relative paths to require() calls
-        createAssets: ({frontMatter}: {frontMatter: DocFrontMatter}) => ({
-          image: frontMatter.image,
+          resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
+            const version = getVersionFromSourceFilePath(
+              sourceFilePath,
+              versionsMetadata,
+            );
+            return resolveMarkdownLinkPathname(linkPathname, {
+              sourceFilePath,
+              sourceToPermalink: contentHelpers.sourceToPermalink,
+              siteDir,
+              contentPaths: version,
+            });
+          },
         }),
-        markdownConfig: siteConfig.markdown,
-        resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
-          const version = getVersionFromSourceFilePath(
-            sourceFilePath,
-            versionsMetadata,
-          );
-          return resolveMarkdownLinkPathname(linkPathname, {
-            sourceFilePath,
-            sourceToPermalink: contentHelpers.sourceToPermalink,
-            siteDir,
-            contentPaths: version,
-          });
-        },
       },
     });
   }

--- a/packages/docusaurus-plugin-content-pages/src/index.ts
+++ b/packages/docusaurus-plugin-content-pages/src/index.ts
@@ -15,7 +15,10 @@ import {
   getContentPathList,
   resolveMarkdownLinkPathname,
 } from '@docusaurus/utils';
-import {createMDXLoaderRule} from '@docusaurus/mdx-loader';
+import {
+  createMDXLoaderOptionsBuilder,
+  createMDXLoaderRule,
+} from '@docusaurus/mdx-loader';
 import {createAllRoutes} from './routes';
 import {createPagesContentPaths, loadPagesContent} from './content';
 import {createContentHelpers} from './contentHelpers';
@@ -53,46 +56,48 @@ export default async function pluginContentPages(
     } = options;
     const contentDirs = getContentPathList(contentPaths);
 
+    const mdxOptionsBuilder = createMDXLoaderOptionsBuilder({
+      siteDir,
+      siteConfig,
+      useCrossCompilerCache:
+        siteConfig.future.experimental_faster.mdxCrossCompilerCache,
+    });
+
     return createMDXLoaderRule({
       include: contentDirs
         // Trailing slash is important, see https://github.com/facebook/docusaurus/pull/3970
         .map(addTrailingPathSeparator),
       options: {
-        useCrossCompilerCache:
-          siteConfig.future.experimental_faster.mdxCrossCompilerCache,
-        admonitions,
-        remarkPlugins,
-        rehypePlugins,
-        recmaPlugins,
-        beforeDefaultRehypePlugins,
-        beforeDefaultRemarkPlugins,
-        staticDirs: siteConfig.staticDirectories.map((dir) =>
-          path.resolve(siteDir, dir),
-        ),
-        siteDir,
-        isMDXPartial: createAbsoluteFilePathMatcher(
-          options.exclude,
-          contentDirs,
-        ),
-        metadataPath: (mdxPath: string) => {
-          // Note that metadataPath must be the same/in-sync as
-          // the path from createData for each MDX.
-          const aliasedSource = aliasedSitePath(mdxPath, siteDir);
-          return path.join(dataDir, `${docuHash(aliasedSource)}.json`);
-        },
-        // createAssets converts relative paths to require() calls
-        createAssets: ({frontMatter}: {frontMatter: PageFrontMatter}) => ({
-          image: frontMatter.image,
+        ...mdxOptionsBuilder.build({
+          admonitions,
+          remarkPlugins,
+          rehypePlugins,
+          recmaPlugins,
+          beforeDefaultRehypePlugins,
+          beforeDefaultRemarkPlugins,
+          isMDXPartial: createAbsoluteFilePathMatcher(
+            options.exclude,
+            contentDirs,
+          ),
+          metadataPath: (mdxPath: string) => {
+            // Note that metadataPath must be the same/in-sync as
+            // the path from createData for each MDX.
+            const aliasedSource = aliasedSitePath(mdxPath, siteDir);
+            return path.join(dataDir, `${docuHash(aliasedSource)}.json`);
+          },
+          // createAssets converts relative paths to require() calls
+          createAssets: ({frontMatter}: {frontMatter: PageFrontMatter}) => ({
+            image: frontMatter.image,
+          }),
+          resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
+            return resolveMarkdownLinkPathname(linkPathname, {
+              sourceFilePath,
+              sourceToPermalink: contentHelpers.sourceToPermalink,
+              siteDir,
+              contentPaths,
+            });
+          },
         }),
-        markdownConfig: siteConfig.markdown,
-        resolveMarkdownLink: ({linkPathname, sourceFilePath}) => {
-          return resolveMarkdownLinkPathname(linkPathname, {
-            sourceFilePath,
-            sourceToPermalink: contentHelpers.sourceToPermalink,
-            siteDir,
-            contentPaths,
-          });
-        },
       },
     });
   }

--- a/packages/docusaurus/src/server/plugins/synthetic.ts
+++ b/packages/docusaurus/src/server/plugins/synthetic.ts
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import {createMDXLoaderItem} from '@docusaurus/mdx-loader';
+import {
+  createMDXLoaderItem,
+  createMDXLoaderOptionsBuilder,
+} from '@docusaurus/mdx-loader';
 import type {RuleSetRule} from 'webpack';
 import type {
   HtmlTagObject,
@@ -79,19 +81,21 @@ export async function createMDXFallbackPlugin({
   siteDir,
   siteConfig,
 }: LoadContext): Promise<InitializedPlugin> {
-  const mdxLoaderItem = await createMDXLoaderItem({
+  const mdxOptionsBuilder = createMDXLoaderOptionsBuilder({
+    siteDir,
+    siteConfig,
     useCrossCompilerCache:
       siteConfig.future.experimental_faster.mdxCrossCompilerCache,
-    admonitions: true,
-    staticDirs: siteConfig.staticDirectories.map((dir) =>
-      path.resolve(siteDir, dir),
-    ),
-    siteDir,
-    // External MDX files are always meant to be imported as partials
-    isMDXPartial: () => true,
-    // External MDX files might have front matter, just disable the warning
-    isMDXPartialFrontMatterWarningDisabled: true,
-    markdownConfig: siteConfig.markdown,
+  });
+
+  const mdxLoaderItem = await createMDXLoaderItem({
+    ...mdxOptionsBuilder.build({
+      admonitions: true,
+      // External MDX files are always meant to be imported as partials
+      isMDXPartial: () => true,
+      // External MDX files might have front matter, just disable the warning
+      isMDXPartialFrontMatterWarningDisabled: true,
+    }),
   });
 
   return {


### PR DESCRIPTION
## Problem
Multiple content plugins (docs/blog/pages) plus the synthetic MDX fallback plugin each re-assembled the same MDX loader "base" options (`siteDir`, `staticDirs`, `markdownConfig`, `useCrossCompilerCache`). This created shotgun surgery when changing common MDX loader setup.

## Approach
- Added a minimal `createMDXLoaderOptionsBuilder()` in `@docusaurus/mdx-loader` that centralizes the shared base options and returns a `build(overrides)` merge result.
- Kept plugin-specific one-offs (matchers, `metadataPath`, `createAssets`, `resolveMarkdownLink`, plugin-specific remark/rehype/recma configuration, etc.) at each call site via the override object.
- Migrated call sites mechanically to use the builder:
  - docs/content-docs webpack MDX rule
  - blog MDX loader item setup
  - pages/content-pages webpack MDX rule
  - synthetic MDX fallback plugin loader item

## Evidence
- Added snapshot/equivalence test for builder output shape: `packages/docusaurus-mdx-loader/src/__tests__/optionsBuilder.test.ts`
- Existing MDX loader tests remain green: `packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts`
- Verified locally:
  `npm test -- --runTestsByPath packages/docusaurus-mdx-loader/src/__tests__/createMDXLoader.test.ts packages/docusaurus-mdx-loader/src/__tests__/optionsBuilder.test.ts`

Closes #77