### PR TITLE
P3/issue 75 Added createOptionsValidator to prevent code duplication

### DIFF
--- a/packages/docusaurus-plugin-content-blog/src/options.ts
+++ b/packages/docusaurus-plugin-content-blog/src/options.ts
@@ -14,6 +14,7 @@ import {
   AdmonitionsSchema,
   RouteBasePathSchema,
   URISchema,
+  createOptionsValidator,
 } from '@docusaurus/utils-validation';
 import {DEFAULT_PLUGIN_ID, GlobExcludeDefault} from '@docusaurus/utils';
 import type {
@@ -22,7 +23,6 @@ import type {
   FeedType,
   FeedXSLTOptions,
 } from '@docusaurus/plugin-content-blog';
-import type {OptionValidationContext} from '@docusaurus/types';
 
 export const DEFAULT_OPTIONS: PluginOptions = {
   id: DEFAULT_PLUGIN_ID,
@@ -248,10 +248,7 @@ const PluginOptionSchema = Joi.object<PluginOptions>({
     .default(DEFAULT_OPTIONS.onUntruncatedBlogPosts),
 }).default(DEFAULT_OPTIONS);
 
-export function validateOptions({
-  validate,
-  options,
-}: OptionValidationContext<Options | undefined, PluginOptions>): PluginOptions {
-  const validatedOptions = validate(PluginOptionSchema, options);
-  return validatedOptions;
-}
+export const validateOptions = createOptionsValidator<
+  Options | undefined,
+  PluginOptions
+>(PluginOptionSchema);

--- a/packages/docusaurus-plugin-content-pages/src/options.ts
+++ b/packages/docusaurus-plugin-content-pages/src/options.ts
@@ -13,9 +13,9 @@ import {
   AdmonitionsSchema,
   RouteBasePathSchema,
   URISchema,
+  createOptionsValidator,
 } from '@docusaurus/utils-validation';
 import {DEFAULT_PLUGIN_ID, GlobExcludeDefault} from '@docusaurus/utils';
-import type {OptionValidationContext} from '@docusaurus/types';
 import type {PluginOptions, Options} from '@docusaurus/plugin-content-pages';
 
 export const DEFAULT_OPTIONS: PluginOptions = {
@@ -60,10 +60,6 @@ const PluginOptionSchema = Joi.object<PluginOptions>({
   editLocalizedFiles: Joi.boolean().default(DEFAULT_OPTIONS.editLocalizedFiles),
 });
 
-export function validateOptions({
-  validate,
-  options,
-}: OptionValidationContext<Options, PluginOptions>): PluginOptions {
-  const validatedOptions = validate(PluginOptionSchema, options);
-  return validatedOptions;
-}
+export const validateOptions = createOptionsValidator<Options, PluginOptions>(
+  PluginOptionSchema,
+);

--- a/packages/docusaurus-plugin-sitemap/src/options.ts
+++ b/packages/docusaurus-plugin-sitemap/src/options.ts
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Joi} from '@docusaurus/utils-validation';
+import {Joi, createOptionsValidator} from '@docusaurus/utils-validation';
 import {ChangeFreqList, LastModOptionList} from './types';
-import type {OptionValidationContext} from '@docusaurus/types';
 import type {
   ChangeFreq,
   LastModOption,
@@ -117,10 +116,6 @@ const PluginOptionSchema = Joi.object<PluginOptions>({
   filename: Joi.string().default(DEFAULT_OPTIONS.filename),
 });
 
-export function validateOptions({
-  validate,
-  options,
-}: OptionValidationContext<Options, PluginOptions>): PluginOptions {
-  const validatedOptions = validate(PluginOptionSchema, options);
-  return validatedOptions;
-}
+export const validateOptions = createOptionsValidator<Options, PluginOptions>(
+  PluginOptionSchema,
+);

--- a/packages/docusaurus-utils-validation/src/index.ts
+++ b/packages/docusaurus-utils-validation/src/index.ts
@@ -11,6 +11,7 @@ export {JoiFrontMatter} from './JoiFrontMatter';
 
 export {
   printWarning,
+  createOptionsValidator,
   normalizePluginOptions,
   normalizeThemeConfig,
   validateFrontMatter,

--- a/packages/docusaurus-utils-validation/src/validationUtils.ts
+++ b/packages/docusaurus-utils-validation/src/validationUtils.ts
@@ -106,3 +106,17 @@ ${errorDetails.map(({message}) => message)}
 
   return value;
 }
+
+type OptionsValidationContext<In, Out> = {
+  validate: (schema: Joi.ObjectSchema<Out>, options: In) => Out;
+  options: In;
+};
+
+export function createOptionsValidator<In, Out>(schema: Joi.ObjectSchema<Out>) {
+  return function validateOptions({
+    validate,
+    options,
+  }: OptionsValidationContext<In, Out>): Out {
+    return validate(schema, options);
+  };
+}


### PR DESCRIPTION
Closes https://github.com/dpantaleoni/docusaurus/issues/75

## Summary of changes

* Added createOptionsValidator() to @docusaurus/utils-validation.
* Exported the helper from packages/docusaurus-utils-validation/src/index.ts.
* Replaced duplicated hand-written validateOptions() wrappers in:
  * packages/docusaurus-plugin-content-pages/src/options.ts
  * packages/docusaurus-plugin-content-blog/src/options.ts
  * packages/docusaurus-plugin-sitemap/src/options.ts
* Preserved each plugin’s existing Joi schema and validation behavior.