### PR TITLE
P3/issue 76 Refactored createImportNode() 

### DIFF
--- a/packages/docusaurus-remark-plugin-npm2yarn/src/index.ts
+++ b/packages/docusaurus-remark-plugin-npm2yarn/src/index.ts
@@ -127,46 +127,55 @@ const isParent = (node: Node): node is Parent =>
 const isNpm2Yarn = (node: Node): node is Code =>
   node.type === 'code' && (node as Code).meta === 'npm2yarn';
 
+type ImportBinding = {
+  localName: string;
+  source: string;
+};
+
+function createImportSourceLiteral(source: string) {
+  return {
+    type: 'Literal',
+    value: source,
+    raw: `'${source}'`,
+  };
+}
+
+function createDefaultImportSpecifier(localName: string) {
+  return {
+    type: 'ImportDefaultSpecifier',
+    local: {type: 'Identifier', name: localName},
+  };
+}
+
+function createDefaultImportDeclaration({localName, source}: ImportBinding) {
+  return {
+    type: 'ImportDeclaration',
+    specifiers: [createDefaultImportSpecifier(localName)],
+    source: createImportSourceLiteral(source),
+  };
+}
+
+function createImportProgram(imports: ImportBinding[]) {
+  return {
+    type: 'Program',
+    body: imports.map(createDefaultImportDeclaration),
+    sourceType: 'module',
+  };
+}
+
 function createImportNode() {
+  const imports = [
+    {localName: 'Tabs', source: '@theme/Tabs'},
+    {localName: 'TabItem', source: '@theme/TabItem'},
+  ];
+
   return {
     type: 'mdxjsEsm',
-    value:
-      "import Tabs from '@theme/Tabs'\nimport TabItem from '@theme/TabItem'",
+    value: imports
+      .map(({localName, source}) => `import ${localName} from '${source}'`)
+      .join('\n'),
     data: {
-      estree: {
-        type: 'Program',
-        body: [
-          {
-            type: 'ImportDeclaration',
-            specifiers: [
-              {
-                type: 'ImportDefaultSpecifier',
-                local: {type: 'Identifier', name: 'Tabs'},
-              },
-            ],
-            source: {
-              type: 'Literal',
-              value: '@theme/Tabs',
-              raw: "'@theme/Tabs'",
-            },
-          },
-          {
-            type: 'ImportDeclaration',
-            specifiers: [
-              {
-                type: 'ImportDefaultSpecifier',
-                local: {type: 'Identifier', name: 'TabItem'},
-              },
-            ],
-            source: {
-              type: 'Literal',
-              value: '@theme/TabItem',
-              raw: "'@theme/TabItem'",
-            },
-          },
-        ],
-        sourceType: 'module',
-      },
+      estree: createImportProgram(imports),
     },
   };
 }


### PR DESCRIPTION
Closes https://github.com/dpantaleoni/docusaurus/issues/76

## Summary of changes

* Refactored createImportNode() in packages/docusaurus-remark-plugin-npm2yarn/src/index.ts.
* Replaced the large inline ESTree object literal with focused builder helpers:
   * createImportSourceLiteral
   * createDefaultImportSpecifier
   * createDefaultImportDeclaration
   * createImportProgram
* Kept generated MDX import text and ESTree shape equivalent for Tabs and TabItem.